### PR TITLE
Add ATT&CK BERT: a cybersecurity language model

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,30 @@ let args = omegajail::Args{
 let result = omegajail::jail::Command::new(args).spawn()?.wait()?;
 println!("{:?}", result);
 ```
+
+## ATT&CK BERT Usage
+
+ATT&CK BERT is a cybersecurity domain-specific language model based on sentence-transformers. ATT&CK BERT maps sentences representing attack actions to a semantically meaningful embedding vector. Embedding vectors of sentences with similar meanings have a high cosine similarity.
+
+### Installation
+
+Using this model becomes easy when you have sentence-transformers installed:
+
+```sh
+pip install -U sentence-transformers
+```
+
+### Example Code
+
+```python
+from sentence_transformers import SentenceTransformer
+sentences = ["Attacker takes a screenshot", "Attacker captures the screen"]
+
+model = SentenceTransformer('basel/ATTACK-BERT')
+embeddings = model.encode(sentences)
+
+from sklearn.metrics.pairwise import cosine_similarity
+print(cosine_similarity([embeddings[0]], [embeddings[1]]))
+```
+
+To use ATT&CK BERT to map text to ATT&CK techniques, check our tool SMET: https://github.com/basel-a/SMET

--- a/src/attack_bert.rs
+++ b/src/attack_bert.rs
@@ -1,0 +1,14 @@
+use sentence_transformers::SentenceTransformer;
+use sklearn::metrics::pairwise::cosine_similarity;
+
+pub fn load_attack_bert_model() -> SentenceTransformer {
+    SentenceTransformer::from_pretrained("basel/ATTACK-BERT")
+}
+
+pub fn encode_sentences(model: &SentenceTransformer, sentences: &[&str]) -> Vec<Vec<f32>> {
+    model.encode(sentences)
+}
+
+pub fn calculate_cosine_similarity(embedding1: &[f32], embedding2: &[f32]) -> f32 {
+    cosine_similarity(embedding1, embedding2)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,5 @@ pub mod sys;
 
 pub use args::Args;
 pub use jail::Command;
+
+pub mod attack_bert;


### PR DESCRIPTION
Add implementation of ATT&CK BERT for mapping sentences to embedding vectors.

* **README.md**
  - Add a section for ATT&CK BERT usage.
  - Include installation instructions for `sentence-transformers`.
  - Provide example code for using ATT&CK BERT.

* **src/attack_bert.rs**
  - Import necessary libraries (`sentence_transformers`, `sklearn`).
  - Define a function to load the ATT&CK BERT model.
  - Implement a function to encode sentences using the model.
  - Add a function to calculate cosine similarity between embeddings.

* **src/lib.rs**
  - Add a module declaration for `attack_bert`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Chemically-Motivated-Solutions/eval-python/pull/5?shareId=698538d9-9194-4fb9-a05e-5be533cdf189).